### PR TITLE
support use by schedview

### DIFF
--- a/spheremap/__init__.py
+++ b/spheremap/__init__.py
@@ -1,1 +1,5 @@
 from .spheremap import *
+from .armillary import ArmillarySphere
+from .horizon import HorizonMap
+from .mollweide import MollweideMap
+from .planisphere import Planisphere

--- a/tests/test_armillary.py
+++ b/tests/test_armillary.py
@@ -54,7 +54,7 @@ class TestArmillarySphere(unittest.TestCase):
         hpvalues = RNG.random(hp.nside2npix(nside))
 
         # make_healpix_data_source calls _add_projection_columns
-        data_source = test_map._make_healpix_data_source(hpvalues, nside=nside)
+        data_source = test_map.make_healpix_data_source(hpvalues, nside=nside)
         self.assertIsInstance(data_source, bokeh.models.ColumnDataSource)
 
     def test_set_js_update_func(self):

--- a/tests/test_horizon.py
+++ b/tests/test_horizon.py
@@ -16,7 +16,7 @@ class TestHorizonMap(unittest.TestCase):
         hpvalues = RNG.random(hp.nside2npix(nside))
 
         # make_healpix_data_source calls add_projection_columns
-        data_source = test_map._make_healpix_data_source(hpvalues, nside=nside)
+        data_source = test_map.make_healpix_data_source(hpvalues, nside=nside)
         self.assertIsInstance(data_source, bokeh.models.ColumnDataSource)
 
     def test_set_js_update_func(self):

--- a/tests/test_mollweide.py
+++ b/tests/test_mollweide.py
@@ -16,7 +16,7 @@ class TestMollweideMap(unittest.TestCase):
         hpvalues = RNG.random(hp.nside2npix(nside))
 
         # make_healpix_data_source calls _add_projection_columns
-        data_source = test_map._make_healpix_data_source(hpvalues, nside=nside)
+        data_source = test_map.make_healpix_data_source(hpvalues, nside=nside)
         self.assertIsInstance(data_source, bokeh.models.ColumnDataSource)
 
     def test_many(self):

--- a/tests/test_spheremap.py
+++ b/tests/test_spheremap.py
@@ -110,7 +110,7 @@ class TestSphereMap(unittest.TestCase):
 
         test_map = SphereMap(mjd=TEST_MJD, location="Cerro Pachon")
 
-        data_source = test_map._make_healpix_data_source(hpvalues, nside=nside)
+        data_source = test_map.make_healpix_data_source(hpvalues, nside=nside)
         self.assertIsInstance(data_source, bokeh.models.ColumnDataSource)
 
         self.assertEqual(len(data_source.data["value"]), npix - 1)


### PR DESCRIPTION
original refactor to make spheremap standalone was too enthusiastic about marking some members private.