### PR TITLE
Update test dependency versions in pyproject.toml, unpin black

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,10 +38,10 @@ dependencies = [
 [project.optional-dependencies]
 test = [
     "pytest",
-    "black == 22.10.0",
-    "pytest-black == 0.3.12",
-    "flake8 == 4.0.1",
-    "pytest-flake8 == 1.1.1",
+    "black",
+    "pytest-black",
+    "flake8 < 5",
+    "pytest-flake8",
 ]
 
 [tool.setuptools.dynamic]


### PR DESCRIPTION
I missed the pyproject.toml definitions of the versions for black/etc. This updates those to match the test-requirements.txt file.