### PR TITLE
return a single transform, not a list, as part of hpix_cmap

### DIFF
--- a/uranography/spheremap.py
+++ b/uranography/spheremap.py
@@ -151,7 +151,7 @@ class SphereMap:
         if len(cmap_transform) == 0 and self._hpix_cmap is not None:
             cmap = self._hpix_cmap
         else:
-            cmap = {"field": "value", "transform": cmap_transform}
+            cmap = {"field": "value", "transform": cmap_transform[0]}
         return cmap
 
     @property


### PR DESCRIPTION
A method intended to make it easy to reuse an existing colormap was returning values in the wrong format, such that it could not be reused directly as intended: it's supposed to be a dictionary with the name of the field to be transformed into a color, and the transform itself. What it was doing was returning the dictionary as the name of the field and a list of transforms (one element long), causing attempts at reuse (including one of the tests in schedview) to fail.