### PR TITLE
force firefox always to be headless in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "colorcet",
     "jupyter",
     "nbconvert",
-    "selenium",
+    "selenium >= 4.10.0",
 ]
 
 [project.urls]

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -5,6 +5,7 @@ import bokeh.io
 import healpy as hp
 import numpy as np
 import pandas as pd
+from selenium import webdriver
 
 TEST_MJD = 60300
 RNG = np.random.default_rng(seed=6563)
@@ -44,7 +45,11 @@ def exercise_map_class(MapClass):
     with TemporaryDirectory() as test_dir:
         out_path = Path(test_dir)
         png_fname = out_path.joinpath("test_plot.png")
-        bokeh.io.export_png(test_map.figure, filename=png_fname)
+
+        firefox_options = webdriver.FirefoxOptions()
+        firefox_options.add_argument("-headless")
+        firefox_webdriver = webdriver.Firefox(options=firefox_options)
+        bokeh.io.export_png(test_map.figure, filename=png_fname, webdriver=firefox_webdriver)
 
 
 def make_simple_map(cls):

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -6,6 +6,7 @@ import healpy as hp
 import numpy as np
 import pandas as pd
 from selenium import webdriver
+from selenium.webdriver.firefox.firefox_binary import FirefoxBinary
 
 TEST_MJD = 60300
 RNG = np.random.default_rng(seed=6563)
@@ -46,8 +47,10 @@ def exercise_map_class(MapClass):
         out_path = Path(test_dir)
         png_fname = out_path.joinpath("test_plot.png")
 
+        firefox_binary = FirefoxBinary()
         firefox_options = webdriver.FirefoxOptions()
         firefox_options.add_argument("-headless")
+        firefox_options.binary = firefox_binary
         firefox_webdriver = webdriver.Firefox(options=firefox_options)
         bokeh.io.export_png(test_map.figure, filename=png_fname, webdriver=firefox_webdriver)
 


### PR DESCRIPTION
This should fix the tests that fail (in some environments) with complaints about missing firefox and geckodriver, but which had nothing to do with missing firefox or geckodriver. These were caused by two problems: first, mamba seems to sometimes install incompatible versions of urllib3 and selenium; and second, even when selenium and urllib were compatible, on some (but not all) systems, selenium would actually try to start a firefox browser window, and die when if it couldn't.
These changes in this pull request force firefox to be headless during the relevant tests, and ensures the selenium installed is recent enough that the API I used to do so actually works. This seems to fix the urllib3 and selenium compatibility problem as well (which was about the version of selenium being too old for the version of urllib3). If it doesn't, there may need to be a separate ticket to guarantee compatible versions.