### PR TITLE
tickets/PREOPS-4851: update for pytest 8 and black 24

### DIFF
--- a/.github/workflows/python_tests.yaml
+++ b/.github/workflows/python_tests.yaml
@@ -44,6 +44,9 @@ jobs:
       - name: conda list
         shell: bash -l {0}
         run: conda list
+      - name: black format test
+        shell: bash -l {0}
+        run: black --check .
       - name: run unit tests
         shell: bash -l {0}
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
       - id: trailing-whitespace
       - id: check-toml
   - repo: https://github.com/psf/black
-    rev: 23.7.0
+    rev: 24.1.1
     hooks:
       - id: black
         # It is recommended to specify the latest version of Python

--- a/uranography/armillary.py
+++ b/uranography/armillary.py
@@ -1,5 +1,6 @@
 """Interactive sky map that works like an armillary sphere.
 """
+
 import bokeh
 import numpy as np
 import panel as pn

--- a/uranography/planisphere.py
+++ b/uranography/planisphere.py
@@ -1,6 +1,5 @@
 """Interactive planisphere (Lambert Azimuthal Equal Area projection)."""
 
-
 import healpy as hp
 import numpy as np
 


### PR DESCRIPTION
Nothing was actually needed for the update to pytest 8, because it wasn't using pytest-black anyway.